### PR TITLE
Replaced pdftk with pdfunite

### DIFF
--- a/Vorlesungen/ThProg/Makefile
+++ b/Vorlesungen/ThProg/Makefile
@@ -11,7 +11,7 @@ cleanup:
 	@-rm -f *.aux *.fdb_latexmk *.fls *.log
 
 single: all
-	@-pdftk Polynomordnung.pdf Konfluenz.pdf SystemF.pdf Koinduktion_reduktion.pdf Strukturelle_Induktion.pdf PumpingLemma.pdf cat output ThProgCheatsheet.pdf
+	@-pdfunite Polynomordnung.pdf Konfluenz.pdf SystemF.pdf Koinduktion_reduktion.pdf Strukturelle_Induktion.pdf PumpingLemma.pdf ThProgCheatsheet.pdf
 	
 
 %.continuous: %.pdf


### PR DESCRIPTION
pdftk is no longer in repos of recent distributions due to licensing issues, so I replaced it with pdfunite from poppler-utils, which has the same functionality.